### PR TITLE
Java 1.5 Compability

### DIFF
--- a/junit-runners/pom.xml
+++ b/junit-runners/pom.xml
@@ -129,8 +129,8 @@
         <inherited>true</inherited>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.5</source>
+          <target>1.5</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This made NestedRunner to compile on Java1.5 for older projects, too.
